### PR TITLE
style: removing the gray color on tablets and desktops views

### DIFF
--- a/scss/components/_consult-block.scss
+++ b/scss/components/_consult-block.scss
@@ -11,7 +11,6 @@
 
   @media screen and (min-width: 40.5em) {
     width: 20.5rem;
-    background-color: gray;
   }
 
   .consult-block__header {


### PR DESCRIPTION
There was a color rewrite on the last media-querie added before.